### PR TITLE
Remove Firebase config lines from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,13 +9,6 @@ firebase-debug.log*
 # Firebase cache
 .firebase/
 
-# Firebase config
-
-# Uncomment this if you'd like others to create their own Firebase project.
-# For a team working on the same Firebase project(s), it is recommended to leave
-# it commented so all members can deploy to the same project(s) in .firebaserc.
-# .firebaserc
-
 # Runtime data
 pids
 *.pid


### PR DESCRIPTION
## Summary
- clean up `.gitignore` by dropping unused Firebase config section

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6841615367408332bb60d6e27d66bf9b