### PR TITLE
Fix parallax stacking context

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,7 @@
       overflow: hidden;
       background: black;
       perspective: 1px;
+      z-index: 0;
     }
 
     .block-layer {


### PR DESCRIPTION
## Summary
- ensure block-layer doesn't hide behind the body by setting `z-index: 0` on `.blocky-parallax`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684164c4f9bc83328f320a7a2302b6d0